### PR TITLE
mb -  'inactive field is required' when editing org with inactivity=false

### DIFF
--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationEditPage.jsx
@@ -54,7 +54,10 @@ export default function UCSBOrganizationEditPage({ storybook = false }) {
   const { isSuccess } = mutation;
 
   const onSubmit = async (data) => {
-    mutation.mutate(data);
+    mutation.mutate({
+      ...data,
+      inactive: data.inactive === "true", // "true"/"false" -> boolean
+    });
   };
 
   if (isSuccess && !storybook) {
@@ -69,7 +72,11 @@ export default function UCSBOrganizationEditPage({ storybook = false }) {
           <UCSBOrganizationForm
             submitAction={onSubmit}
             buttonLabel={"Update"}
-            initialContents={ucsbOrganization}
+            initialContents={{
+              ...ucsbOrganization,
+              // make it "true"/"false" so RHF sees a non-empty value
+              inactive: String(ucsbOrganization.inactive),
+            }}
           />
         )}
       </div>


### PR DESCRIPTION
Fixed issue with 'inactive field is required' when an organization with inactive=false had its inactivity unedited when editing an organization.